### PR TITLE
Add option to hide max HP enemies

### DIFF
--- a/src/SRTPluginRE9/src/Hook/UI.cpp
+++ b/src/SRTPluginRE9/src/Hook/UI.cpp
@@ -185,6 +185,8 @@ namespace SRTPluginRE9::Hook
 			}
 		}
 
+		ImGui::Checkbox("Hide full HP enemies", &hideFullHPEnemies);
+
 		ImGui::End();
 	}
 
@@ -396,7 +398,7 @@ namespace SRTPluginRE9::Hook
 
 			for (const auto &enemyData : std::span(static_cast<EnemyData *>(localGameData.FilteredEnemies.Values), localGameData.FilteredEnemies.Size) | std::views::take(g_SRTSettings.EnemiesShownLimit))
 			{
-				if (enemyData.HP.CurrentHP >= 1000000)
+				if (enemyData.HP.CurrentHP >= 1'000'000 || (hideFullHPEnemies && enemyData.HP.CurrentHP == enemyData.HP.MaximumHP))
 				{
 					continue;
 				}

--- a/src/SRTPluginRE9/src/Hook/include/UI.h
+++ b/src/SRTPluginRE9/src/Hook/include/UI.h
@@ -59,6 +59,7 @@ namespace SRTPluginRE9::Hook
 		int32_t logoWidth = 0;
 		int32_t logoHeight = 0;
 		float logoScaleFactor = .5f;
+		bool hideFullHPEnemies = false;
 
 		std::atomic<uint32_t> reportedBadDA = 0;
 		std::atomic<uint32_t> reportedBadPlayerHP = 0;


### PR DESCRIPTION
Checkbox option to hide enemies with full HP from being displayed on the overlay