### PR TITLE
Add color customization

### DIFF
--- a/src/SRTPluginRE9/src/Hook/Settings.cpp
+++ b/src/SRTPluginRE9/src/Hook/Settings.cpp
@@ -67,7 +67,13 @@ static void SRTSettings_ReadLine(ImGuiContext *, ImGuiSettingsHandler *, void * 
 		readSuccess = TryReadSetting(inputStringView, "OverlayOpacity=", g_SRTSettings.OverlayOpacity);
 
 	if (!readSuccess)
+		readSuccess = TryReadSetting(inputStringView, "ShowCustomizationOptions=", g_SRTSettings.ShowCustomizationOptions);
+	if (!readSuccess)
 		readSuccess = TryReadSetting(inputStringView, "EnemiesShownLimit=", g_SRTSettings.EnemiesShownLimit);
+	if (!readSuccess)
+		readSuccess = TryReadSetting(inputStringView, "EnemiesFullHPTextColorIndex=", g_SRTSettings.EnemiesFullHPTextColorIndex);
+	if (!readSuccess)
+		readSuccess = TryReadSetting(inputStringView, "EnemiesInjuredTextColorIndex=", g_SRTSettings.EnemiesInjuredTextColorIndex);
 	if (!readSuccess)
 		readSuccess = TryReadSetting(inputStringView, "EnemiesHideFullHP=", g_SRTSettings.EnemiesHideFullHP);
 	if (!readSuccess)
@@ -78,6 +84,12 @@ static void SRTSettings_ReadLine(ImGuiContext *, ImGuiSettingsHandler *, void * 
 		readSuccess = TryReadSetting(inputStringView, "EnemyHPBarsWidth=", g_SRTSettings.EnemyHPBarsWidth);
 	if (!readSuccess)
 		readSuccess = TryReadSetting(inputStringView, "EnemyHPBarsHeight=", g_SRTSettings.EnemyHPBarsHeight);
+	if (!readSuccess)
+		readSuccess = TryReadSetting(inputStringView, "EnemyHPBarForeColorIndex=", g_SRTSettings.EnemyHPBarForeColorIndex);
+	if (!readSuccess)
+		readSuccess = TryReadSetting(inputStringView, "EnemyHPBarBackColorIndex=", g_SRTSettings.EnemyHPBarBackColorIndex);
+	if (!readSuccess)
+		readSuccess = TryReadSetting(inputStringView, "DarkenBarColors=", g_SRTSettings.DarkenBarColors);
 
 	if (!readSuccess)
 		readSuccess = TryReadSetting(inputStringView, "DPIScalingFactor=", g_SRTSettings.DPIScalingFactor);
@@ -101,12 +113,18 @@ static void SRTSettings_WriteAll(ImGuiContext *, ImGuiSettingsHandler *handler, 
 
 	out_buf->appendf("OverlayOpacity=%f\n", g_SRTSettings.OverlayOpacity);
 
+	out_buf->appendf("ShowCustomizationOptions=%d\n", g_SRTSettings.ShowCustomizationOptions);
 	out_buf->appendf("EnemiesShownLimit=%d\n", g_SRTSettings.EnemiesShownLimit);
+	out_buf->appendf("EnemiesFullHPTextColorIndex=%d\n", g_SRTSettings.EnemiesFullHPTextColorIndex);
+	out_buf->appendf("EnemiesInjuredTextColorIndex=%d\n", g_SRTSettings.EnemiesInjuredTextColorIndex);
 	out_buf->appendf("EnemiesHideFullHP=%d\n", g_SRTSettings.EnemiesHideFullHP);
 	out_buf->appendf("EnemyHPBarsVisible=%d\n", g_SRTSettings.EnemyHPBarsVisible);
 	out_buf->appendf("EnemyHPBarsShowPercent=%d\n", g_SRTSettings.EnemyHPBarsShowPercent);
 	out_buf->appendf("EnemyHPBarsWidth=%f\n", g_SRTSettings.EnemyHPBarsWidth);
 	out_buf->appendf("EnemyHPBarsHeight=%f\n", g_SRTSettings.EnemyHPBarsHeight);
+	out_buf->appendf("EnemyHPBarForeColorIndex=%d\n", g_SRTSettings.EnemyHPBarForeColorIndex);
+	out_buf->appendf("EnemyHPBarBackColorIndex=%d\n", g_SRTSettings.EnemyHPBarBackColorIndex);
+	out_buf->appendf("DarkenBarColors=%d\n", g_SRTSettings.DarkenBarColors);
 
 	out_buf->appendf("DPIScalingFactor=%f\n", g_SRTSettings.DPIScalingFactor);
 	out_buf->appendf("FontScalingFactor=%f\n", g_SRTSettings.FontScalingFactor);

--- a/src/SRTPluginRE9/src/Hook/UI.cpp
+++ b/src/SRTPluginRE9/src/Hook/UI.cpp
@@ -190,15 +190,28 @@ namespace SRTPluginRE9::Hook
 			}
 		}
 
-		ImGui::Checkbox("Show HP bars", reinterpret_cast<bool *>(&g_SRTSettings.EnemyHPBarsVisible));
-		if (g_SRTSettings.EnemyHPBarsVisible)
+		ImGui::Checkbox("Show customization options", reinterpret_cast<bool *>(&g_SRTSettings.ShowCustomizationOptions));
+		if (g_SRTSettings.ShowCustomizationOptions)
 		{
-			ImGui::SameLine();
-			ImGui::Checkbox("Show HP percent", reinterpret_cast<bool *>(&g_SRTSettings.EnemyHPBarsShowPercent));
-			BarSizeSlider("Width", g_SRTSettings.EnemyHPBarsWidth, 20.0f, 300.0f);
-			BarSizeSlider("Height", g_SRTSettings.EnemyHPBarsHeight, 2.0f, 30.0f);
+			ImGui::Checkbox("Hide full HP enemies", reinterpret_cast<bool *>(&g_SRTSettings.EnemiesHideFullHP));
+			if (!g_SRTSettings.EnemiesHideFullHP)
+			{
+				ImGui::Combo("Full HP enemy text color", &g_SRTSettings.EnemiesFullHPTextColorIndex, colorPresets, IM_ARRAYSIZE(colorPresets));
+			}
+			ImGui::Combo("Injured enemy text color", &g_SRTSettings.EnemiesInjuredTextColorIndex, colorPresets, IM_ARRAYSIZE(colorPresets));
+
+			ImGui::Checkbox("Show HP bars", reinterpret_cast<bool *>(&g_SRTSettings.EnemyHPBarsVisible));
+			if (g_SRTSettings.EnemyHPBarsVisible)
+			{
+				ImGui::SameLine();
+				ImGui::Checkbox("Show HP percent", reinterpret_cast<bool *>(&g_SRTSettings.EnemyHPBarsShowPercent));
+				BarSizeSlider("Width", g_SRTSettings.EnemyHPBarsWidth, 20.0f, 300.0f);
+				BarSizeSlider("Height", g_SRTSettings.EnemyHPBarsHeight, 2.0f, 30.0f);
+				ImGui::Combo("Foreground color", &g_SRTSettings.EnemyHPBarForeColorIndex, colorPresets, IM_ARRAYSIZE(colorPresets));
+				ImGui::Combo("Background color", &g_SRTSettings.EnemyHPBarBackColorIndex, colorPresets, IM_ARRAYSIZE(colorPresets));
+				ImGui::Checkbox("Darken bar colors", reinterpret_cast<bool *>(&g_SRTSettings.DarkenBarColors));
+			}
 		}
-		ImGui::Checkbox("Hide full HP enemies", reinterpret_cast<bool *>(&g_SRTSettings.EnemiesHideFullHP));
 
 		ImGui::End();
 	}
@@ -418,38 +431,16 @@ namespace SRTPluginRE9::Hook
 				auto name_display = enemies.contains(enemyData.KindID) ? enemies.at(enemyData.KindID) : std::format("{}", enemyData.KindID);
 				if (enemyData.HP.CurrentHP != enemyData.HP.MaximumHP)
 				{
-					ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.5f, 1.0f), "%s %" PRIi32 " / %" PRIi32, name_display.c_str(), enemyData.HP.CurrentHP, enemyData.HP.MaximumHP);
+					ImGui::TextColored(ColorFromPreset(g_SRTSettings.EnemiesInjuredTextColorIndex), "%s %" PRIi32 " / %" PRIi32, name_display.c_str(), enemyData.HP.CurrentHP, enemyData.HP.MaximumHP);
 				}
 				else
 				{
-					ImGui::Text("%s %" PRIi32 " / %" PRIi32, name_display.c_str(), enemyData.HP.CurrentHP, enemyData.HP.MaximumHP);
+					ImGui::TextColored(ColorFromPreset(g_SRTSettings.EnemiesFullHPTextColorIndex), "%s %" PRIi32 " / %" PRIi32, name_display.c_str(), enemyData.HP.CurrentHP, enemyData.HP.MaximumHP);
 				}
 
 				if (g_SRTSettings.EnemyHPBarsVisible)
 				{
-					const auto hpPercent = enemyData.HP.MaximumHP > 0
-					                           ? static_cast<float>(enemyData.HP.CurrentHP) / static_cast<float>(enemyData.HP.MaximumHP)
-					                           : 0.0f;
-
-					// Fill color
-					ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(0.20f, 0.80f, 0.20f, 1.00f));
-
-					// Back color
-					ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.20f, 0.20f, 0.80f, 1.00f));
-
-					// Scale by the font scale factor so that the bars remain proportional to the text size
-					const auto width = g_SRTSettings.EnemyHPBarsWidth * g_SRTSettings.FontScalingFactor;
-					const auto height = g_SRTSettings.EnemyHPBarsHeight * g_SRTSettings.FontScalingFactor;
-
-					ImGui::ProgressBar(hpPercent, ImVec2(width, height), "");
-
-					ImGui::PopStyleColor(2);
-
-					if (g_SRTSettings.EnemyHPBarsShowPercent)
-					{
-						ImGui::SameLine();
-						ImGui::Text("%.1f%%", hpPercent * 100.0f);
-					}
+					RenderHPBar(enemyData.HP.CurrentHP, enemyData.HP.MaximumHP);
 				}
 			}
 		}
@@ -486,6 +477,65 @@ namespace SRTPluginRE9::Hook
 			    ImVec4(0, 0, 0, 0));
 		}
 		ImGui::End();
+	}
+
+	void STDMETHODCALLTYPE UI::RenderHPBar(int32_t curHP, int32_t maxHP)
+	{
+		const auto hpPercent = maxHP > 0
+		                           ? static_cast<float>(curHP) / static_cast<float>(maxHP)
+		                           : 0.0f;
+
+		// Fill color
+		ImVec4 foreColor = ColorFromPreset(g_SRTSettings.EnemyHPBarForeColorIndex);
+		if (g_SRTSettings.DarkenBarColors)
+		{
+			foreColor.x *= 0.7f;
+			foreColor.y *= 0.7f;
+			foreColor.z *= 0.7f;
+		}
+		ImGui::PushStyleColor(ImGuiCol_PlotHistogram, foreColor);
+
+		// Back color
+		ImVec4 backColor = ColorFromPreset(g_SRTSettings.EnemyHPBarBackColorIndex);
+		if (g_SRTSettings.DarkenBarColors)
+		{
+			backColor.x *= 0.7f;
+			backColor.y *= 0.7f;
+			backColor.z *= 0.7f;
+		}
+		ImGui::PushStyleColor(ImGuiCol_FrameBg, backColor);
+
+		// Scale by the font scale factor so that the bars remain proportional to the text size
+		const auto width = g_SRTSettings.EnemyHPBarsWidth * g_SRTSettings.FontScalingFactor;
+		const auto height = g_SRTSettings.EnemyHPBarsHeight * g_SRTSettings.FontScalingFactor;
+
+		ImGui::ProgressBar(hpPercent, ImVec2(width, height), "");
+
+		ImGui::PopStyleColor(2);
+
+		if (g_SRTSettings.EnemyHPBarsShowPercent)
+		{
+			ImGui::SameLine();
+			ImGui::Text("%.1f%%", hpPercent * 100.0f);
+		}
+	}
+
+	ImVec4 STDMETHODCALLTYPE UI::ColorFromPreset(int32_t preset)
+	{
+		switch (static_cast<ColorPreset>(preset))
+		{
+			case ColorPreset::Blue:
+				return ImVec4(0.2f, 0.2f, 0.8f, 1.0f);
+			case ColorPreset::Red:
+				return ImVec4(0.8f, 0.2f, 0.2f, 1.0f);
+			case ColorPreset::Green:
+				return ImVec4(0.2f, 0.8f, 0.2f, 1.0f);
+			case ColorPreset::Gray:
+				return ImVec4(0.4f, 0.4f, 0.4f, 1.0f);
+		}
+
+		// Return white as default
+		return ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
 	}
 
 	void STDMETHODCALLTYPE UI::GameWindowResized()

--- a/src/SRTPluginRE9/src/Hook/include/Settings.h
+++ b/src/SRTPluginRE9/src/Hook/include/Settings.h
@@ -25,12 +25,18 @@ struct SRTSettings
 
 	float OverlayOpacity = .2f;
 
+	uint32_t ShowCustomizationOptions = 0U; // false
 	int EnemiesShownLimit = 16;
 	uint32_t EnemiesHideFullHP = 1U;      // true
+	int32_t EnemiesFullHPTextColorIndex = 4; // white
+	int32_t EnemiesInjuredTextColorIndex = 1; // red
 	uint32_t EnemyHPBarsVisible = 0U;     // false
 	uint32_t EnemyHPBarsShowPercent = 0U; // false
 	float EnemyHPBarsWidth = 100.f;
 	float EnemyHPBarsHeight = 10.f;
+	int32_t EnemyHPBarForeColorIndex = 2; // green
+	int32_t EnemyHPBarBackColorIndex = 0; // blue
+	uint32_t DarkenBarColors = 0U; // false
 
 	float DPIScalingFactor = 0.f;
 	float FontScalingFactor = 0.f;

--- a/src/SRTPluginRE9/src/Hook/include/UI.h
+++ b/src/SRTPluginRE9/src/Hook/include/UI.h
@@ -28,6 +28,15 @@ namespace SRTPluginRE9::Hook
 		LowerRight = 3
 	};
 
+	enum class ColorPreset : int32_t
+	{
+		Blue = 0,
+		Red = 1,
+		Green = 2,
+		White = 3,
+		Gray = 4
+	};
+
 	class UI
 	{
 	public:
@@ -47,6 +56,8 @@ namespace SRTPluginRE9::Hook
 		void STDMETHODCALLTYPE DrawDebugLogger();
 		void STDMETHODCALLTYPE DrawDebugOverlay();
 		void STDMETHODCALLTYPE DrawLogoOverlay();
+		void STDMETHODCALLTYPE RenderHPBar(int32_t currentHP, int32_t maximumHP);
+		ImVec4 STDMETHODCALLTYPE ColorFromPreset(int32_t preset);
 
 		float horizontal;
 		float vertical;
@@ -58,6 +69,7 @@ namespace SRTPluginRE9::Hook
 		bool aboutUIOpen = false;
 
 		const char *logoPositions[4]{"Upper Left", "Upper Right", "Lower Left", "Lower Right"};
+		const char *colorPresets[5]{"Blue", "Red", "Green", "White", "Gray"};
 		SRTPluginRE9::Hook::DescriptorHandle logoHandle;
 		ID3D12Resource *logoTexture = nullptr;
 		int32_t logoWidth = 0;


### PR DESCRIPTION
* Add some preset color options for enemy HP text and bars
* Add checkbox to show/hide customization options to not clutter UI
* Allow for settings to save and load

<img width="1185" height="363" alt="image" src="https://github.com/user-attachments/assets/29b7055b-811f-42c6-bfa6-8a94f98a726f" />
